### PR TITLE
bugfix - 解决收藏夹URL匹配不完善问题: 私有收藏夹是9位.

### DIFF
--- a/util.go
+++ b/util.go
@@ -24,7 +24,7 @@ const (
 
 var (
 	reQuestionURL    = regexp.MustCompile("^(http|https)://www.zhihu.com/question/[0-9]{8}$")
-	reCollectionURL  = regexp.MustCompile("^(http|https)://www.zhihu.com/collection/[0-9]{8}$")
+	reCollectionURL  = regexp.MustCompile("^(http|https)://www.zhihu.com/collection/[0-9]{8,9}$") // bugfix: for private collection
 	reTopicURL       = regexp.MustCompile("^(http|https)://www.zhihu.com/topic/[0-9]{8}$")
 	reGetNumber      = regexp.MustCompile(`([0-9])+`)
 	reAvatarReplacer = regexp.MustCompile(`_(s|xs|m|l|xl|hd).(png|jpg)`)


### PR DESCRIPTION

- 对收藏夹的正则匹配, 做了补充.